### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,5 +1,8 @@
 name: Go Lint
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Sif3r/auth-service/security/code-scanning/2](https://github.com/Sif3r/auth-service/security/code-scanning/2)

To address the issue, the `permissions` key should be added to the workflow. Since this workflow only performs linting operations, it does not require write access. The permissions block will be set to `contents: read`, which is the least privilege required to access the repository's code.

The fix involves:
1. Adding a `permissions` block at the root level of the workflow to apply to all jobs in the workflow.
2. Ensuring that no additional permissions are granted unnecessarily.

The modifications will be made to the file `.github/workflows/go-lint.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
